### PR TITLE
Server /api/filebrowser implementation

### DIFF
--- a/server/src/config.ts
+++ b/server/src/config.ts
@@ -1,0 +1,23 @@
+import path from 'path';
+
+const projectRoot = path.resolve(__dirname, '..');
+
+const port = process.env.PORT || 8443;
+
+let sslKeyPath = process.env.SSL_KEY_PATH || '.keys/server-key.pem';
+let sslCertPath = process.env.SSL_CERT_PATH || '.keys/server-cert.pem';
+let clientPath = process.env.CLIENT_PATH || '../client/build';
+let fileBrowserRoot = process.env.FILEBROWSER_ROOT || '../client';
+
+sslKeyPath = path.resolve(projectRoot, sslKeyPath);
+sslCertPath = path.resolve(projectRoot, sslCertPath);
+clientPath = path.resolve(projectRoot, clientPath);
+fileBrowserRoot = path.resolve(projectRoot, fileBrowserRoot);
+
+export const config = {
+  port,
+  sslKeyPath,
+  sslCertPath,
+  clientPath,
+  fileBrowserRoot,
+};

--- a/server/src/index.ts
+++ b/server/src/index.ts
@@ -1,5 +1,4 @@
 import fs from 'fs';
-import path from 'path';
 import express from 'express';
 import spdy from 'spdy';
 
@@ -7,16 +6,8 @@ import { handlePostLogin } from 'server/route/login/post';
 import { handleGetFilebrowser } from './route/filebrowser/get';
 import { jsonErrorHandler } from './middleware/jsonErrorHandler';
 
-const projectRoot = path.resolve(__dirname, '..');
-
-let sslKeyPath = process.env.SSL_KEY_PATH || '.keys/server-key.pem';
-let sslCertPath = process.env.SSL_CERT_PATH || '.keys/server-cert.pem';
-let clientPath = process.env.CLIENT_PATH || '../client/build';
-const port = process.env.PORT || 8443;
-
-sslKeyPath = path.resolve(projectRoot, sslKeyPath);
-sslCertPath = path.resolve(projectRoot, sslCertPath);
-clientPath = path.resolve(projectRoot, clientPath);
+import { config } from 'server/config';
+const { port, sslKeyPath, sslCertPath, clientPath } = config;
 
 const app = express();
 
@@ -28,7 +19,7 @@ app.post('/api/logout', (req, res) => {
   res.status(200).send('stub');
 });
 
-app.get('/api/filebrowser', handleGetFilebrowser);
+app.get('/api/filebrowser/?*', handleGetFilebrowser);
 
 // fallback route for paths starting in '/api'
 app.use('/api', (req, res) => {

--- a/server/src/lib/ErrorWithCode.ts
+++ b/server/src/lib/ErrorWithCode.ts
@@ -4,7 +4,9 @@ export type ErrorCode =
   | 'auth/notAuthorized'
   | 'login/failed'
   | 'login/validation/username'
-  | 'login/validation/password';
+  | 'login/validation/password'
+  | 'filebrowser/noEntry'
+  | 'filebrowser/notDirectory';
 
 class ErrorWithCode extends Error {
   code: ErrorCode;

--- a/server/src/middleware/jsonErrorHandler.ts
+++ b/server/src/middleware/jsonErrorHandler.ts
@@ -8,6 +8,8 @@ const httpStatusCodeMap: Record<ErrorCode, number> = {
   'login/validation/username': 400,
   'login/validation/password': 400,
   'login/failed': 400,
+  'filebrowser/noEntry': 400,
+  'filebrowser/notDirectory': 400,
 };
 
 export const jsonErrorHandler: ErrorRequestHandler = (err, req, res, next) => {

--- a/server/src/model/filebrowser.ts
+++ b/server/src/model/filebrowser.ts
@@ -1,0 +1,80 @@
+import fs from 'fs/promises';
+import path from 'path';
+
+import { ErrorWithCode } from 'server/lib/ErrorWithCode';
+
+import { config } from 'server/config';
+const { fileBrowserRoot } = config;
+
+type Entry = {
+  name: string;
+  type: 'file' | 'directory';
+  size: number;
+};
+
+// node.js throws `Error`s with several additional properties added, such as
+// `code`. These properties are specified in the `NodeJS.ErrnoException`
+// interface, but the errors thrown by node.js are still `instanceof Error`.
+// This function supplies type narrowing to allow access to those additional
+// properties.
+const isNodeJsError = (err: unknown): err is NodeJS.ErrnoException => {
+  if (typeof err !== 'object') {
+    return false;
+  }
+  if (err === null) {
+    return false;
+  }
+  if ('code' in err) {
+    return true;
+  }
+  return false;
+};
+
+export const readdir = async (rawPath: string): Promise<Entry[]> => {
+  let absolutePath = path.join(fileBrowserRoot, rawPath);
+  absolutePath = path.normalize(absolutePath);
+
+  // fail fast if `rawPath` lies outside `fileBrowserRoot` (e.g. it has '..'
+  // components)
+  const relativePath = path.relative(fileBrowserRoot, absolutePath);
+  if (relativePath.startsWith('..')) {
+    throw new ErrorWithCode({
+      code: 'filebrowser/noEntry',
+      message: `The file "${rawPath}" does not exist.`,
+    });
+  }
+
+  const result: Entry[] = [];
+  let files: string[] = [];
+
+  try {
+    files = await fs.readdir(absolutePath);
+  } catch (err) {
+    if (isNodeJsError(err)) {
+      if (err.code === 'ENOENT') {
+        throw new ErrorWithCode({
+          code: 'filebrowser/noEntry',
+          message: `The file "${rawPath}" does not exist.`,
+        });
+      } else if (err.code === 'ENOTDIR') {
+        throw new ErrorWithCode({
+          code: 'filebrowser/notDirectory',
+          message: `The file "${rawPath}" is not a directory.`,
+        });
+      }
+    }
+    throw err;
+  }
+
+  for (const file of files) {
+    const stats = await fs.stat(path.join(absolutePath, file));
+    const type = stats.isDirectory() ? 'directory' : 'file';
+    result.push({
+      name: file,
+      type,
+      size: stats.size,
+    });
+  }
+
+  return result;
+};

--- a/server/src/route/filebrowser/get.ts
+++ b/server/src/route/filebrowser/get.ts
@@ -1,8 +1,13 @@
 import { makeRequestHandler } from 'server/lib/makeRequestHandler';
 import { assertAuthorized } from 'server/model/session';
+import { readdir } from 'server/model/filebrowser';
 
-export const handleGetFilebrowser = makeRequestHandler((req, res) => {
+export const handleGetFilebrowser = makeRequestHandler(async (req, res) => {
   assertAuthorized(req, ['read:filebrowser']);
 
-  res.status(200).send('stub');
+  let filepath = req.params[0] || '';
+  filepath = decodeURIComponent(filepath);
+
+  const entries = await readdir(filepath);
+  res.status(200).send(JSON.stringify(entries));
 });

--- a/server/template.env
+++ b/server/template.env
@@ -5,3 +5,6 @@ PORT=8443
 # Directory from which to serve client files. Any request not starting in
 # '/api' will be served from this directory.
 CLIENT_PATH='../client/build'
+
+# Directory from which to list entries when calling /api/filebrowser
+FILEBROWSER_ROOT='../client'


### PR DESCRIPTION
- Added FILEBROWSER_ROOT environment variable to represent the root
  directory from which to list entries for /api/filebrowser
- Moved processing of environment variables into src/config.ts (now that
  more than one file needs to access them)

Note: this is using the `t/server/login` branch as a base because it depends on the session management implemented in that branch. I'll rebase to `main` once PR #4 is merged.