### PR TITLE
Client FileBrowser implementation

### DIFF
--- a/client/src/api/filebrowser.ts
+++ b/client/src/api/filebrowser.ts
@@ -1,0 +1,27 @@
+import { makeRequest } from './makeRequest';
+
+export type Entry = {
+  name: string;
+  type: 'file' | 'directory';
+  size: number;
+};
+
+export const filebrowser = async ({
+  path,
+  sessionId,
+}: {
+  path: string;
+  sessionId: string;
+}): Promise<Entry[]> => {
+  const encodedPath = window.encodeURIComponent(path);
+
+  const response = await makeRequest({
+    method: 'GET',
+    url: `/api/filebrowser/${encodedPath}`,
+    headers: {
+      'Session-Id': sessionId,
+    },
+  });
+
+  return response as Entry[];
+};

--- a/client/src/api/login.ts
+++ b/client/src/api/login.ts
@@ -1,14 +1,7 @@
-import { ErrorWithCode } from 'client/lib/ErrorWithCode';
 import { makeRequest } from './makeRequest';
 
 type LoginResponse = {
   sessionId: string;
-};
-
-const isLoginResponse = (
-  obj: Record<string, unknown>,
-): obj is LoginResponse => {
-  return typeof obj.sessionId === 'string';
 };
 
 export const login = async ({
@@ -29,12 +22,5 @@ export const login = async ({
     body,
   });
 
-  if (!isLoginResponse(response)) {
-    throw new ErrorWithCode({
-      code: 'api/unexpectedResponse',
-      message: 'Something unexpected went wrong. Please try again later.',
-    });
-  }
-
-  return response;
+  return response as LoginResponse;
 };

--- a/client/src/api/makeRequest.ts
+++ b/client/src/api/makeRequest.ts
@@ -4,19 +4,30 @@ export const makeRequest = async ({
   url,
   method,
   body,
+  headers,
 }: {
   url: string;
   method: string;
-  body: Record<string, unknown>;
-}): Promise<Record<string, unknown>> => {
-  const response = await window.fetch(url, {
+  body?: Record<string, unknown>;
+  headers?: Record<string, string>;
+}): Promise<unknown> => {
+  let opts: RequestInit = {
     method,
-    body: JSON.stringify(body),
-    headers: {
-      'content-type': 'application/json',
-    },
-  });
+    headers,
+  };
 
+  if (body !== undefined) {
+    opts = {
+      ...opts,
+      body: JSON.stringify(body),
+      headers: {
+        'content-type': 'application/json',
+        ...headers,
+      },
+    };
+  }
+
+  const response = await window.fetch(url, opts);
   const json = (await response.json()) as unknown;
 
   if (!response.ok) {

--- a/client/src/components/Breadcrumbs.tsx
+++ b/client/src/components/Breadcrumbs.tsx
@@ -1,0 +1,43 @@
+import React, { ReactElement, ReactNode } from 'react';
+import { Link } from 'client/router/Link';
+import { encodeParts, normalize } from 'client/lib/path';
+
+export const Breadcrumbs = ({
+  cwd,
+  linkPrefix,
+}: {
+  cwd: string;
+  linkPrefix: string;
+}): ReactElement => {
+  let parts: string[] = cwd.split('/');
+  if (cwd === '/') {
+    parts = [''];
+  }
+
+  return (
+    <div className="Breadcrumbs">
+      {parts.map(
+        (part, i): ReactNode => {
+          let name = part;
+          if (i === 0) {
+            name = 'root';
+          }
+          // the last path component shouldn't be a Link (you're already on the
+          // route it would link to)
+          if (i === parts.length - 1) {
+            return [<div className="pathPart">{name}</div>];
+          }
+          let path = parts.slice(0, i + 1).join('/');
+          path = normalize(`${linkPrefix}/${path}`);
+          path = encodeParts(path);
+          return [
+            <div className="pathPart">
+              <Link to={path}>{name}</Link>
+            </div>,
+            <div className="pathSeparator">/</div>,
+          ];
+        },
+      )}
+    </div>
+  );
+};

--- a/client/src/components/DataGrid.tsx
+++ b/client/src/components/DataGrid.tsx
@@ -1,0 +1,61 @@
+import React, { ReactElement, ReactNode } from 'react';
+
+export type ColumnDefinition<K extends string> = {
+  name: K;
+  title: string;
+};
+
+export type SortInfo<K extends string> = {
+  name: K;
+  direction: 'ascending' | 'descending';
+};
+
+export const DataGrid = function<K extends string>({
+  columns,
+  data,
+  sort,
+  onSortClick,
+}: {
+  columns: ColumnDefinition<K>[];
+  data: Record<K, ReactNode>[];
+  sort: SortInfo<K>;
+  onSortClick: (name: K) => void;
+}): ReactElement {
+  return (
+    <table className="DataGrid">
+      <thead>
+        <tr>
+          {columns.map((col) => {
+            return (
+              <td>
+                <button onClick={(): void => onSortClick(col.name)}>
+                  <div className="columnTitle">{col.title}</div>
+                  <div className="sortIndicator">
+                    {sort && sort.name === col.name
+                      ? sort.direction === 'ascending'
+                        ? '▲'
+                        : '▼'
+                      : ''}
+                  </div>
+                </button>
+              </td>
+            );
+          })}
+        </tr>
+      </thead>
+      <tbody>
+        {data.map((row) => {
+          return (
+            <tr>
+              {columns.map((col) => {
+                const name = col.name;
+                const val = row[name];
+                return <td>{val}</td>;
+              })}
+            </tr>
+          );
+        })}
+      </tbody>
+    </table>
+  );
+};

--- a/client/src/components/FileBrowser.tsx
+++ b/client/src/components/FileBrowser.tsx
@@ -1,5 +1,112 @@
-import React, { ReactElement } from 'react';
+import { Entry } from 'client/api/filebrowser';
+import { getHumanReadableSize } from 'client/lib/numberFormat';
+import { encodeParts, normalize } from 'client/lib/path';
+import { Link } from 'client/router/Link';
+import React, { ReactElement, ReactNode } from 'react';
+import { Breadcrumbs } from './Breadcrumbs';
+import { DataGrid, SortInfo } from './DataGrid';
+import { Highlighted } from './Highlighted';
 
-export const FileBrowser = (): ReactElement => {
-  return <div className="FileBrowser">File browser stub. Hi.</div>;
+const columns = [
+  {
+    name: 'name' as const,
+    title: 'Name',
+  },
+  {
+    name: 'size' as const,
+    title: 'Size',
+  },
+];
+
+export type ColumnNames = (typeof columns)[0]['name'];
+
+const directoryIcon = (
+  <svg
+    className="directoryIcon"
+    aria-label="Directory"
+    aria-hidden="true"
+    height="16"
+    viewBox="0 0 16 16"
+    version="1.1"
+    width="16"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M1.75 1A1.75 1.75 0 000 2.75v10.5C0 14.216.784 15 1.75 15h12.5A1.75 1.75 0 0016 13.25v-8.5A1.75 1.75 0 0014.25 3h-6.5a.25.25 0 01-.2-.1l-.9-1.2c-.33-.44-.85-.7-1.4-.7h-3.5z"
+    />
+  </svg>
+);
+
+const fileIcon = (
+  <svg
+    className="fileIcon"
+    aria-label="File"
+    aria-hidden="true"
+    height="16"
+    viewBox="0 0 16 16"
+    version="1.1"
+    width="16"
+  >
+    <path
+      fill-rule="evenodd"
+      d="M3.75 1.5a.25.25 0 00-.25.25v11.5c0 .138.112.25.25.25h8.5a.25.25 0 00.25-.25V6H9.75A1.75 1.75 0 018 4.25V1.5H3.75zm5.75.56v2.19c0 .138.112.25.25.25h2.19L9.5 2.06zM2 1.75C2 .784 2.784 0 3.75 0h5.086c.464 0 .909.184 1.237.513l3.414 3.414c.329.328.513.773.513 1.237v8.086A1.75 1.75 0 0112.25 15h-8.5A1.75 1.75 0 012 13.25V1.75z"
+    />
+  </svg>
+);
+
+export const FileBrowser = function({
+  cwd,
+  entryList,
+  sort,
+  onSortClick,
+  searchTerm,
+  onSearchTermChange,
+}: {
+  cwd: string;
+  entryList: Entry[];
+  sort: SortInfo<ColumnNames>;
+  onSortClick: (name: ColumnNames) => void;
+  searchTerm: string;
+  onSearchTermChange: (term: string) => void;
+}): ReactElement {
+  const renderEntryName = (entry: Entry): ReactNode => {
+    const name = <Highlighted text={entry.name} term={searchTerm} />;
+    if (entry.type === 'directory') {
+      let path = normalize(`/filebrowser/${cwd}/${entry.name}`);
+      path = encodeParts(path);
+      return [directoryIcon, <Link to={path}>{name}</Link>];
+    }
+    return [fileIcon, name];
+  };
+
+  const data = entryList.map((entry) => {
+    return {
+      name: renderEntryName(entry),
+      size: (
+        <Highlighted
+          text={getHumanReadableSize(entry.size)}
+          term={searchTerm}
+        />
+      ),
+    };
+  });
+
+  return (
+    <div className="FileBrowser">
+      <Breadcrumbs cwd={cwd} linkPrefix={'/filebrowser'} />
+      <input
+        className="FileBrowserSearch"
+        type="text"
+        placeholder="Search"
+        onChange={(e): void => onSearchTermChange(e.target.value)}
+        value={searchTerm}
+      />
+      <DataGrid
+        columns={columns}
+        data={data}
+        sort={sort}
+        onSortClick={onSortClick}
+      />
+    </div>
+  );
 };

--- a/client/src/components/FileBrowserWrapper.tsx
+++ b/client/src/components/FileBrowserWrapper.tsx
@@ -1,0 +1,93 @@
+import React, { ReactElement, useState, useEffect } from 'react';
+
+import { Entry, filebrowser } from 'client/api/filebrowser';
+import { makeAuthenticatedRequest } from 'client/store';
+import { FileBrowser, ColumnNames } from './FileBrowser';
+import { decodeParts, normalize } from 'client/lib/path';
+import { SortInfo } from './DataGrid';
+import { getHumanReadableSize } from 'client/lib/numberFormat';
+
+type URL = typeof window.URL.prototype;
+
+const getFilebrowserCwd = (url: URL): string => {
+  const path = url.pathname.replace(/^\/filebrowser/, '');
+  return decodeParts(normalize(`/${path}`));
+};
+
+const lexicographicSort = function<T>(a: T, b: T): number {
+  if (a > b) {
+    return 1;
+  }
+  if (a < b) {
+    return -1;
+  }
+  return 0;
+};
+
+export const FileBrowserWrapper = ({ url }: { url: URL }): ReactElement => {
+  const cwd = getFilebrowserCwd(url);
+  const [entries, setEntries] = useState<Entry[]>([]);
+  const [searchTerm, setSearchTerm] = useState('');
+  const [sort, setSort] = useState<SortInfo<ColumnNames>>({
+    name: 'name',
+    direction: 'ascending',
+  });
+
+  useEffect(() => {
+    void makeAuthenticatedRequest(async (sessionId) => {
+      const entries = await filebrowser({ path: cwd, sessionId });
+      setSearchTerm('');
+      setEntries(entries);
+    });
+  }, [url]);
+
+  let entryList = entries;
+
+  if (searchTerm) {
+    entryList = entryList.filter((entry) => {
+      return (
+        entry.name.indexOf(searchTerm) !== -1 ||
+        getHumanReadableSize(entry.size).indexOf(searchTerm) !== -1
+      );
+    });
+  }
+
+  entryList.sort(
+    (a, b): number => {
+      const reverse = sort.direction === 'descending' ? -1 : 1;
+      if (sort.name === 'name') {
+        return lexicographicSort(a.name, b.name) * reverse;
+      }
+      if (sort.name === 'size') {
+        return (a.size - b.size) * reverse;
+      }
+      return 0;
+    },
+  );
+
+  const onSortClick = (name: ColumnNames): void => {
+    if (sort.name !== name) {
+      setSort({
+        name,
+        direction: 'ascending',
+      });
+      return;
+    }
+
+    setSort({
+      name,
+      direction: sort.direction === 'ascending' ? 'descending' : 'ascending',
+    });
+  };
+
+  return (
+    <FileBrowser
+      cwd={cwd}
+      entryList={entryList}
+      sort={sort}
+      onSortClick={onSortClick}
+      searchTerm={searchTerm}
+      onSearchTermChange={setSearchTerm}
+    />
+  );
+};

--- a/client/src/components/Highlighted.tsx
+++ b/client/src/components/Highlighted.tsx
@@ -1,0 +1,24 @@
+import React, { ReactElement } from 'react';
+
+export const Highlighted = ({
+  text,
+  term,
+}: {
+  text: string;
+  term: string;
+}): ReactElement => {
+  if (!term) {
+    return <span>{text}</span>;
+  }
+  const i = text.indexOf(term);
+  if (i === -1) {
+    return <span>{text}</span>;
+  }
+  return (
+    <span>
+      {text.slice(0, i)}
+      <strong>{text.slice(i, i + term.length)}</strong>
+      {text.slice(i + term.length)}
+    </span>
+  );
+};

--- a/client/src/lib/numberFormat.ts
+++ b/client/src/lib/numberFormat.ts
@@ -1,0 +1,25 @@
+const BASE = 1024;
+
+export const getHumanReadableSize = (size: number): string => {
+  const exp = Math.log(size) / Math.log(BASE);
+  let scaled = '';
+  let prefix = '';
+
+  if (exp >= 4) {
+    scaled = (size / BASE**4).toFixed(1);
+    prefix = 'T';
+  } else if (exp >= 3) {
+    scaled = (size / BASE**3).toFixed(1);
+    prefix = 'G';
+  } else if (exp >= 2) {
+    scaled = (size / BASE**2).toFixed(1);
+    prefix = 'M';
+  } else if (exp >= 1) {
+    scaled = (size / BASE).toFixed(1);
+    prefix = 'K';
+  } else {
+    scaled = size.toString();
+  }
+
+  return `${scaled}${prefix}`;
+};

--- a/client/src/lib/path.ts
+++ b/client/src/lib/path.ts
@@ -1,0 +1,52 @@
+const normalizeArray = (parts: string[]): string[] => {
+  const result: string[] = [];
+
+  for (const p of parts) {
+    // ignore empty parts
+    if (!p || p === '.') {
+      continue;
+    }
+
+    if (p === '..') {
+      if (result.length && result[result.length - 1] !== '..') {
+        result.pop();
+      }
+    } else {
+      result.push(p);
+    }
+  }
+
+  return result;
+};
+
+export const normalize = (path: string): string => {
+  const hasTrailingSlash = path && path[path.length - 1] === '/';
+
+  path = normalizeArray(path.split('/')).join('/');
+
+  if (path && hasTrailingSlash) {
+    path += '/';
+  }
+
+  return `/${path}`;
+};
+
+// like `window.encodeURIComponent`, but keep "/" characters intact to improve
+// URL readability
+export const encodeParts = (path: string): string => {
+  return path
+    .split('/')
+    .map((part) => {
+      return window.encodeURIComponent(part);
+    })
+    .join('/');
+};
+
+export const decodeParts = (path: string): string => {
+  return path
+    .split('/')
+    .map((part) => {
+      return window.decodeURIComponent(part);
+    })
+    .join('/');
+};

--- a/client/src/router/Link.tsx
+++ b/client/src/router/Link.tsx
@@ -1,0 +1,21 @@
+import React, { ReactElement, ReactNode } from 'react';
+
+export const Link = ({
+  to,
+  children,
+}: {
+  to: string;
+  children: ReactNode;
+}): ReactElement => {
+  const onClick = (event: React.SyntheticEvent): void => {
+    event.preventDefault();
+    window.history.pushState(null, '', to);
+    window.dispatchEvent(new window.PopStateEvent('popstate'));
+  };
+
+  return (
+    <a href={to} onClick={onClick}>
+      {children}
+    </a>
+  );
+};

--- a/client/src/router/Router.tsx
+++ b/client/src/router/Router.tsx
@@ -1,6 +1,6 @@
 import React, { ReactElement } from 'react';
 
-import { FileBrowser } from 'client/components/FileBrowser';
+import { FileBrowserWrapper } from 'client/components/FileBrowserWrapper';
 import { LoginWrapper } from 'client/components/LoginWrapper';
 import { useStore } from 'client/store';
 import { gotoRoute } from './gotoRoute';
@@ -30,7 +30,7 @@ export const Router = ({ url }: { url: URL }): ReactElement => {
   }
 
   if (path.startsWith('/filebrowser')) {
-    return <FileBrowser />;
+    return <FileBrowserWrapper url={url} />;
   }
 
   return <div>404</div>;

--- a/client/src/style.css
+++ b/client/src/style.css
@@ -1,3 +1,13 @@
+html,
+body {
+  font-family: Helvetica, Arial, sans-serif;
+  font-size: 14px;
+}
+
+strong {
+  font-weight: 600;
+}
+
 .App {
   display: flex;
   flex-direction: column;
@@ -28,4 +38,87 @@
 
 .Login ul.server-error {
   color: red;
+}
+
+.Breadcrumbs {
+  font-size: 16px;
+  font-weight: 600;
+  margin-bottom: 20px;
+}
+
+.Breadcrumbs .pathPart,
+.Breadcrumbs .pathSeparator {
+  display: inline-block;
+  padding-right: 10px;
+}
+
+.FileBrowserSearch {
+  margin-bottom: 20px;
+}
+
+.DataGrid {
+  border: 1px solid rgb(208, 215, 222);
+}
+
+.DataGrid tbody td {
+  position: relative;
+  padding: 8px;
+}
+
+.DataGrid tbody td:first-child {
+  padding-left: 31px;
+}
+
+.directoryIcon {
+  position: absolute;
+  top: 7px;
+  left: 7px;
+}
+
+.fileIcon {
+  position: absolute;
+  top: 8px;
+  left: 7px;
+}
+
+.DataGrid thead {
+  background: rgba(0, 0, 0, 0.1);
+}
+
+.DataGrid thead td {
+  height: 40px;
+}
+
+.DataGrid thead button {
+  border: 0 none;
+  width: 100%;
+  height: 100%;
+  text-align: left;
+  padding: 8px;
+}
+
+.DataGrid thead button:hover {
+  background: rgba(0, 0, 0, 0.11);
+}
+
+.DataGrid thead button:active {
+  background: rgba(0, 0, 0, 0.15);
+}
+
+.DataGrid thead .columnTitle,
+.DataGrid thead .sortIndicator {
+  display: inline-block;
+}
+
+.DataGrid thead .sortIndicator {
+  width: 20px;
+  margin-left: 10px;
+}
+
+.DataGrid tr {
+  border-bottom: 1px solid rgb(208, 215, 222);
+}
+
+.DataGrid tr:hover {
+  background: rgb(246, 248, 250);
 }


### PR DESCRIPTION
This is an implementation of FileBrowser as it's described in the design doc. tl;dr of server/README.md and client/README.md to get this running:

```sh
$ cd client
$ make
$ cd server
$ make
# (trust the .keys/ca-cert.pem certificate that was generated)
$ yarn run start
# (navigate to https://localhost:8443/filebrowser in a web browser)
```

Preview:

<img width="363" alt="Screen Shot 2021-10-12 at 6 46 41 PM" src="https://user-images.githubusercontent.com/151098/137043812-fd4a47fc-a001-4a58-bf20-b9d1c51f0f59.png">

Note: the git base of this PR is a temporary merge commit of `t/server/filebrowser` and `t/client/login`, both of which have outstanding PRs (#5 and #6). I'll rebase to `main` once those PRs are merged.